### PR TITLE
Update README for cases when dependencies included

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ index: {
   //The name of the routes if you are using the lazy-route mixin, no minisearch expressions are allowed here.
   routes: ["index", "..."]
   //The dependencies for this bundle. They will loaded in the same batch as the actual bundle
+  // The dependencies had to be loaded prior to the dependent bundles.
   dependencies: ["about"],
 },
 about: {


### PR DESCRIPTION
- In scenarios where dependencies are added for routes, the dependencies bundle had to be placed prior to the dependent bundle in `config/bundles.js`
- In dependencies are added after the dependent bundle in `config/bundles.js`, only the dependencies bundles will be loaded for routes.